### PR TITLE
Pr/12 first baseline fix

### DIFF
--- a/apps/api/src/app/comparison/services/comparison.service.spec.ts
+++ b/apps/api/src/app/comparison/services/comparison.service.spec.ts
@@ -4,21 +4,69 @@ import {
   PhotonService,
   CloudProviderService
 } from '@visual-knight/api-interface';
+import { TestSessionState } from '@generated/photonjs';
 
 describe('ComparisonService', () => {
   let service: ComparisonService;
+  let photonService: PhotonService;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ComparisonService,
-        { provide: PhotonService, useValue: {} },
+        {
+          provide: PhotonService,
+          useValue: {
+            testSession: {
+              update: jest.fn()
+            }
+          }
+        },
         { provide: CloudProviderService, useValue: {} }
       ]
     }).compile();
     service = module.get<ComparisonService>(ComparisonService);
+    photonService = module.get<PhotonService>(PhotonService);
   });
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('updateImageData', () => {
+    const params = {
+      testSessionId: 'testSessionId',
+      imageKey: 'testSession.imageKey',
+      state: TestSessionState.UNRESOLVED,
+      diffImageKey: 'diffImageKey',
+      diffBaselineRef: 'diffBaselineRef',
+      misMatchPercentage: 15,
+      isSameDimensions: true
+    };
+
+    it('should update image data', () => {
+      photonService.testSession.update = jest
+        .fn()
+        .mockResolvedValueOnce(params);
+
+      service['updateImageData'](
+        params.testSessionId,
+        params.imageKey,
+        params.state,
+        params.diffImageKey,
+        params.misMatchPercentage,
+        params.isSameDimensions
+      );
+
+      expect(photonService.testSession.update).toHaveBeenCalledWith({
+        where: { id: params.testSessionId },
+        data: {
+          imageKey: params.imageKey,
+          diffImageKey: params.diffImageKey,
+          misMatchPercentage: params.misMatchPercentage,
+          isSameDimensions: params.isSameDimensions,
+          state: params.state
+        }
+      });
+    });
   });
 });

--- a/apps/api/src/app/comparison/services/comparison.service.spec.ts
+++ b/apps/api/src/app/comparison/services/comparison.service.spec.ts
@@ -38,7 +38,6 @@ describe('ComparisonService', () => {
       imageKey: 'testSession.imageKey',
       state: TestSessionState.UNRESOLVED,
       diffImageKey: 'diffImageKey',
-      diffBaselineRef: 'diffBaselineRef',
       misMatchPercentage: 15,
       isSameDimensions: true
     };

--- a/apps/api/src/app/comparison/services/comparison.service.ts
+++ b/apps/api/src/app/comparison/services/comparison.service.ts
@@ -286,7 +286,6 @@ export class ComparisonService {
                 testSession.imageKey,
                 misMatchTolerance < misMatchPercentage || !isSameDimensions ? 'UNRESOLVED' : 'ACCEPTED',
                 diffImageKey,
-                baselineRef.id,
                 misMatchPercentage,
                 isSameDimensions
               );
@@ -297,7 +296,7 @@ export class ComparisonService {
           return this.updateAutoBaseline(testSession.imageKey, testSessionId, variationId);
         } else {
           console.log('No baseline image exists');
-          return this.updateImageData(testSessionId, testSession.imageKey, 'UNRESOLVED');
+          return this.updateImageData(testSessionId, testSession.imageKey, TestSessionState.UNRESOLVED);
         }
       })
     );
@@ -317,7 +316,7 @@ export class ComparisonService {
                   imageKey: imageKey,
                   isSameDimensions: true,
                   misMatchPercentage: 0,
-                  state: 'ACCEPTED'
+                  state: TestSessionState.ACCEPTED
                 }
               }
             }
@@ -355,7 +354,6 @@ export class ComparisonService {
     imageKey: string,
     state: TestSessionState,
     diffImageKey?: string,
-    diffBaselineRef?: string,
     misMatchPercentage?: number,
     isSameDimensions?: boolean
   ): Observable<TestSession> {
@@ -367,7 +365,6 @@ export class ComparisonService {
         misMatchPercentage,
         isSameDimensions,
         state,
-        baselineForDiffRef: diffBaselineRef ? { connect: { id: diffBaselineRef } } : null
       }
     });
 

--- a/libs/api-interface/schema.prisma
+++ b/libs/api-interface/schema.prisma
@@ -78,10 +78,6 @@ model TestSession {
 
   // baseline reference
   baselineRef Variation? @relation(name: "VariationBaseline")
-
-  // reference to the diff
-  baselineForDiffRef TestSession? @relation(name: "DiffBaselineOnTestSession")
-  diffBaseline       TestSession? @relation(name: "DiffBaselineOnTestSession")
 }
 
 enum Role {


### PR DESCRIPTION
Due to issue in prisma2 https://github.com/prisma/prisma-client-js/issues/459#issuecomment-581823561 it's failing when trying to connect `baselineForDiffRef` with null in `comparison.service.ts`

After some investigation I realized that this field is not used together with `diffBaseline`

Now it works when there is no baseline image - `@visual-knight/core` throws valid error message with url to accept/decline baseline

Let me know if I didn't get purpose of those fields correctly