### PR TITLE
body-parser json limit configuration is added

### DIFF
--- a/.envtemplate
+++ b/.envtemplate
@@ -1,6 +1,7 @@
 VK_APP_SECRET="SOME_APP_SECRET"
 VK_APP_DOMAIN="http://localhost:4200/"
 VK_GRAPHQL_SCHEMA_PATH="apps/api/schema.graphql"
+VK_BODY_PARSER_JSON_LIMIT="1mb"
 
 # EMAIL (only for production)
 VK_EMAIL_USER=""

--- a/apps/api/src/environments/environment.prod.ts
+++ b/apps/api/src/environments/environment.prod.ts
@@ -32,6 +32,7 @@ export const environment = {
   },
 
   appDomain: process.env.VK_APP_DOMAIN,
+  appBodyParserJsonLimit: process.env.VK_BODY_PARSER_JSON_LIMIT,
 
   diffOptions: {
     threshold: 0.01,

--- a/apps/api/src/environments/environment.ts
+++ b/apps/api/src/environments/environment.ts
@@ -32,6 +32,7 @@ export const environment = {
   },
 
   appDomain: process.env.VK_APP_DOMAIN,
+  appBodyParserJsonLimit: process.env.VK_BODY_PARSER_JSON_LIMIT,
 
   diffOptions: {
     threshold: 0.01,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,12 +4,19 @@
  **/
 
 import { NestFactory } from '@nestjs/core';
+import * as bodyParser from 'body-parser';
+import { environment } from './environments/environment';
 
 import { AppModule } from './app/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const port = process.env.port || 3333;
+
+  if (environment.appBodyParserJsonLimit) {
+    app.use(bodyParser.json({ limit: environment.appBodyParserJsonLimit }));
+  }
+
   await app.listen(port, () => {
     console.log('Listening at http://localhost:' + port + '/');
   });


### PR DESCRIPTION
Default setting for json limit is `100kb` that could be not enough for images [body-parser doc](https://github.com/expressjs/body-parser#limit)